### PR TITLE
Do not hide errors while opening images.

### DIFF
--- a/shared/readfile_ome.m
+++ b/shared/readfile_ome.m
@@ -1,7 +1,8 @@
 function img=readfile_ome(file)
 try
 imgall=bfopen(file);
-catch
+catch ME
+    disp(ME);
     disp(['could not open file ' file])
     img=[];
     return


### PR DESCRIPTION
I'm having a lot of trouble with bioformats and loading the example .tif stacks.

This pull request is only a minor suggestion to print the error information that is thrown to the console. Of course, if you're logging errors then you would want to redirect the output to the logger. I'd be happy to do this if you tell me where the logger is.